### PR TITLE
dev/jean: NEW YEAR EVE'S PULL REQUEST

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -24,7 +24,7 @@ func APIServer(port int) {
 	controller.NewDeploymentController(app.Group("deployments"))
 
 	controller.NewHealthController(app.Group("health"))
-	controller.NewPresetController(app.Group("preset"))
+	controller.NewPresetController(app.Group("presets"))
 	controller.NewBuildScriptController(app.Group("build-script"))
 
 	log.Fatal(app.Listen(fmt.Sprintf(":%d", port)))

--- a/apiserver/controller/deployment.go
+++ b/apiserver/controller/deployment.go
@@ -19,6 +19,7 @@ func NewDeploymentController(api fiber.Router) {
 	api.Get("/:deploymentID", getDeployment)
 	api.Get("/:deploymentID/events", getDeploymentEvents)
 	api.Post("/:deploymentID/events", createDeploymentEvents)
+	api.Delete("/:deploymentID", deleteDeployment)
 }
 
 func createDeployment(ctx *fiber.Ctx) error {
@@ -78,4 +79,13 @@ func createDeploymentEvents(ctx *fiber.Ctx) error {
 
 	event, createErr := datastore.SaveEvent(datastore.GetDB(), &inputModel)
 	return writeResponse(ctx, event, createErr)
+}
+
+func deleteDeployment(ctx *fiber.Ctx) error {
+	deploymentID := ctx.Params("deploymentID")
+	err := datastore.RemoveDeployment(datastore.GetDB(), deploymentID)
+	if err != nil {
+		return fiber.NewError(errutil.MapStatusCode(err))
+	}
+	return ctx.SendStatus(fiber.StatusOK)
 }

--- a/apiserver/controller/deployment.go
+++ b/apiserver/controller/deployment.go
@@ -76,7 +76,6 @@ func createDeploymentEvents(ctx *fiber.Ctx) error {
 
 	zap.L().Sugar().Debug(inputModel.Text)
 
-	_ = datastore.SaveEvent(datastore.GetDB(), &inputModel)
-
-	return ctx.SendStatus(fiber.StatusOK)
+	event, createErr := datastore.SaveEvent(datastore.GetDB(), &inputModel)
+	return writeResponse(ctx, event, createErr)
 }

--- a/apiserver/controller/preset.go
+++ b/apiserver/controller/preset.go
@@ -2,15 +2,52 @@ package controller
 
 import (
 	"github.com/gofiber/fiber/v2"
-	"github.com/thecodeisalreadydeployed/preset"
+	"github.com/thecodeisalreadydeployed/apiserver/dto"
+	"github.com/thecodeisalreadydeployed/apiserver/errutil"
+	"github.com/thecodeisalreadydeployed/apiserver/validator"
+	"github.com/thecodeisalreadydeployed/datastore"
 )
 
 func NewPresetController(api fiber.Router) {
-	api.Get("/:preset", getPreset)
+	api.Get("/list", listPresets)
+	api.Get("/:presetID", getPreset)
+	api.Post("/", createPreset)
+	api.Delete("/:presetID", deletePreset)
+}
+
+func listPresets(ctx *fiber.Ctx) error {
+	result, err := datastore.GetAllPresets(datastore.GetDB())
+	return writeResponse(ctx, result, err)
 }
 
 func getPreset(ctx *fiber.Ctx) error {
-	framework := ctx.Params("preset")
-	text := preset.Text(preset.Framework(framework))
-	return ctx.SendString(text)
+	presetID := ctx.Params("presetID")
+	result, err := datastore.GetPresetByID(datastore.GetDB(), presetID)
+	return writeResponse(ctx, result, err)
+}
+
+func createPreset(ctx *fiber.Ctx) error {
+	input := dto.CreatePresetRequest{}
+
+	if err := ctx.BodyParser(&input); err != nil {
+		return fiber.NewError(errutil.MapStatusCode(err))
+	}
+
+	if validationErrors := validator.CheckStruct(input); len(validationErrors) > 0 {
+		return ctx.Status(fiber.StatusBadRequest).JSON(validationErrors)
+	}
+
+	inputModel := input.ToModel()
+	app, createErr := datastore.SavePreset(datastore.GetDB(), &inputModel)
+
+	return writeResponse(ctx, app, createErr)
+}
+
+func deletePreset(ctx *fiber.Ctx) error {
+	presetID := ctx.Params("presetID")
+	err := datastore.RemovePreset(datastore.GetDB(), presetID)
+	if err != nil {
+		return fiber.NewError(errutil.MapStatusCode(err))
+	}
+	return ctx.SendStatus(fiber.StatusOK)
 }

--- a/apiserver/dto/preset.go
+++ b/apiserver/dto/preset.go
@@ -1,0 +1,15 @@
+package dto
+
+import "github.com/thecodeisalreadydeployed/model"
+
+type CreatePresetRequest struct {
+	Name     string `validate:"required"`
+	Template string `validate:"required"`
+}
+
+func (req *CreatePresetRequest) ToModel() model.Preset {
+	return model.Preset{
+		Name:     req.Name,
+		Template: req.Template,
+	}
+}

--- a/datamodel/app.go
+++ b/datamodel/app.go
@@ -43,16 +43,3 @@ func NewAppFromModel(app *model.App) *App {
 		Observable:         app.Observable,
 	}
 }
-
-func AppStructString() []string {
-	return []string{
-		"ID",
-		"ProjectID",
-		"Name",
-		"GitSource",
-		"CreatedAt",
-		"UpdatedAt",
-		"BuildConfiguration",
-		"Observable",
-	}
-}

--- a/datamodel/datamodel_test.go
+++ b/datamodel/datamodel_test.go
@@ -9,46 +9,21 @@ import (
 
 func TestProject_ToModel(t *testing.T) {
 	prj := Project{
-		ID:        "prj_test",
+		ID:        "prj-test",
 		Name:      "Best Project",
 		CreatedAt: time.Unix(1, 0),
 		UpdatedAt: time.Unix(2, 0),
 	}
 
-	expected := model.Project{
-		ID:        "prj_test",
-		Name:      "Best Project",
-		CreatedAt: time.Unix(1, 0),
-		UpdatedAt: time.Unix(2, 0),
-	}
-
-	actual := prj.ToModel()
-	assert.Equal(t, expected, actual)
-}
-
-func TestNewProjectFromModel(t *testing.T) {
-	prj := model.Project{
-		ID:        "prj_test",
-		Name:      "Best Project",
-		CreatedAt: time.Unix(1, 0),
-		UpdatedAt: time.Unix(2, 0),
-	}
-
-	expected := &Project{
-		ID:        "prj_test",
-		Name:      "Best Project",
-		CreatedAt: time.Unix(1, 0),
-		UpdatedAt: time.Unix(2, 0),
-	}
-
-	actual := NewProjectFromModel(&prj)
-	assert.Equal(t, expected, actual)
+	parsed := prj.ToModel()
+	actual := *NewProjectFromModel(&parsed)
+	assert.Equal(t, prj, actual)
 }
 
 func TestApp_ToModel(t *testing.T) {
 	app := App{
-		ID:                 "app_test",
-		ProjectID:          "prj_test",
+		ID:                 "app-test",
+		ProjectID:          "prj-test",
 		Project:            Project{},
 		Name:               "Best App",
 		GitSource:          model.GetGitSourceString(model.GitSource{}),
@@ -58,53 +33,15 @@ func TestApp_ToModel(t *testing.T) {
 		Observable:         false,
 	}
 
-	expected := model.App{
-		ID:                 "app_test",
-		ProjectID:          "prj_test",
-		Name:               "Best App",
-		GitSource:          model.GitSource{},
-		CreatedAt:          time.Unix(1, 0),
-		UpdatedAt:          time.Unix(2, 0),
-		BuildConfiguration: model.BuildConfiguration{},
-		Observable:         false,
-	}
-
-	actual := app.ToModel()
-	assert.Equal(t, expected, actual)
-}
-
-func TestNewAppFromModel(t *testing.T) {
-	app := model.App{
-		ID:                 "app_test",
-		ProjectID:          "prj_test",
-		Name:               "Best App",
-		GitSource:          model.GitSource{},
-		CreatedAt:          time.Unix(1, 0),
-		UpdatedAt:          time.Unix(2, 0),
-		BuildConfiguration: model.BuildConfiguration{},
-		Observable:         false,
-	}
-
-	expected := &App{
-		ID:                 "app_test",
-		ProjectID:          "prj_test",
-		Project:            Project{},
-		Name:               "Best App",
-		GitSource:          model.GetGitSourceString(model.GitSource{}),
-		CreatedAt:          time.Unix(1, 0),
-		UpdatedAt:          time.Unix(2, 0),
-		BuildConfiguration: model.GetBuildConfigurationString(model.BuildConfiguration{}),
-		Observable:         false,
-	}
-
-	actual := NewAppFromModel(&app)
-	assert.Equal(t, expected, actual)
+	parsed := app.ToModel()
+	actual := *NewAppFromModel(&parsed)
+	assert.Equal(t, app, actual)
 }
 
 func TestDeployment_ToModel(t *testing.T) {
 	dpl := Deployment{
-		ID:                 "dpl_test",
-		AppID:              "app_test",
+		ID:                 "dpl-test",
+		AppID:              "app-test",
 		App:                App{},
 		Creator:            model.GetCreatorString(model.Actor{}),
 		Meta:               "dummy_meta",
@@ -118,57 +55,35 @@ func TestDeployment_ToModel(t *testing.T) {
 		State:              model.DeploymentStateReady,
 	}
 
-	expected := model.Deployment{
-		ID:                 "dpl_test",
-		AppID:              "app_test",
-		Creator:            model.Actor{},
-		Meta:               "dummy_meta",
-		GitSource:          model.GitSource{},
-		BuiltAt:            time.Unix(0, 0),
-		CommittedAt:        time.Unix(0, 0),
-		DeployedAt:         time.Unix(0, 0),
-		BuildConfiguration: model.BuildConfiguration{},
-		CreatedAt:          time.Unix(0, 0),
-		UpdatedAt:          time.Unix(0, 0),
-		State:              model.DeploymentStateReady,
-	}
-
-	actual := dpl.ToModel()
-	assert.Equal(t, expected, actual)
+	parsed := dpl.ToModel()
+	actual := *NewDeploymentFromModel(&parsed)
+	assert.Equal(t, dpl, actual)
 }
 
-func TestNewDeploymentFromModel(t *testing.T) {
-	dpl := model.Deployment{
-		ID:                 "dpl_test",
-		AppID:              "app_test",
-		Creator:            model.Actor{},
-		Meta:               "dummy_meta",
-		GitSource:          model.GitSource{},
-		BuiltAt:            time.Unix(0, 0),
-		CommittedAt:        time.Unix(0, 0),
-		DeployedAt:         time.Unix(0, 0),
-		BuildConfiguration: model.BuildConfiguration{},
-		CreatedAt:          time.Unix(0, 0),
-		UpdatedAt:          time.Unix(0, 0),
-		State:              model.DeploymentStateReady,
+func TestEvent_ToModel(t *testing.T) {
+	event := Event{
+		ID:           "abcdefghijklmnopqrstuvwxyz0",
+		DeploymentID: "dpl-test",
+		Text:         "Downloading dependencies (1/20)",
+		Type:         model.INFO,
+		ExportedAt:   time.Unix(0, 0),
+		CreatedAt:    time.Unix(0, 0),
 	}
 
-	expected := &Deployment{
-		ID:                 "dpl_test",
-		AppID:              "app_test",
-		App:                App{},
-		Creator:            model.GetCreatorString(model.Actor{}),
-		Meta:               "dummy_meta",
-		GitSource:          model.GetGitSourceString(model.GitSource{}),
-		BuiltAt:            time.Unix(0, 0),
-		CommittedAt:        time.Unix(0, 0),
-		DeployedAt:         time.Unix(0, 0),
-		BuildConfiguration: model.GetBuildConfigurationString(model.BuildConfiguration{}),
-		CreatedAt:          time.Unix(0, 0),
-		UpdatedAt:          time.Unix(0, 0),
-		State:              model.DeploymentStateReady,
+	parsed := event.ToModel()
+	actual := *NewEventFromModel(&parsed)
+	assert.Equal(t, event, actual)
+}
+
+func TestPreset_ToModel(t *testing.T) {
+	preset := Preset{
+		ID:       "pst-test",
+		Name:     "My Preset",
+		Template: "UlVOIGVjaG8gaGVsbG8=",
 	}
 
-	actual := NewDeploymentFromModel(&dpl)
-	assert.Equal(t, expected, actual)
+	parsed := preset.ToModel()
+	assert.Equal(t, "RUN echo hello", parsed.Template)
+	actual := *NewPresetFromModel(&parsed)
+	assert.Equal(t, preset, actual)
 }

--- a/datamodel/deployment.go
+++ b/datamodel/deployment.go
@@ -55,20 +55,3 @@ func NewDeploymentFromModel(dpl *model.Deployment) *Deployment {
 		UpdatedAt:          dpl.UpdatedAt,
 	}
 }
-
-func DeploymentStructString() []string {
-	return []string{
-		"ID",
-		"AppID",
-		"Creator",
-		"Meta",
-		"GitSource",
-		"BuiltAt",
-		"CommittedAt",
-		"DeployedAt",
-		"BuildConfiguration",
-		"CreatedAt",
-		"UpdatedAt",
-		"State",
-	}
-}

--- a/datamodel/event.go
+++ b/datamodel/event.go
@@ -9,6 +9,7 @@ import (
 type Event struct {
 	ID           string `gorm:"primaryKey"`
 	DeploymentID string
+	Deployment   Deployment `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	Text         string
 	Type         model.EventType
 	ExportedAt   time.Time

--- a/datamodel/preset.go
+++ b/datamodel/preset.go
@@ -1,0 +1,27 @@
+package datamodel
+
+import "github.com/thecodeisalreadydeployed/model"
+
+type Preset struct {
+	ID   string `gorm:"primaryKey"`
+	Name string
+
+	// Stored in base64 encoding.
+	Template string
+}
+
+func (p *Preset) ToModel() model.Preset {
+	return model.Preset{
+		ID:       p.ID,
+		Name:     p.Name,
+		Template: model.GetDecodedString(p.Template),
+	}
+}
+
+func NewPresetFromModel(p *model.Preset) *Preset {
+	return &Preset{
+		ID:       p.ID,
+		Name:     p.Name,
+		Template: model.GetEncodedString(p.Template),
+	}
+}

--- a/datamodel/project.go
+++ b/datamodel/project.go
@@ -30,7 +30,3 @@ func NewProjectFromModel(prj *model.Project) *Project {
 		UpdatedAt: prj.UpdatedAt,
 	}
 }
-
-func ProjectStructString() []string {
-	return []string{"ID", "Name", "CreatedAt", "UpdatedAt"}
-}

--- a/datastore/app.go
+++ b/datastore/app.go
@@ -105,13 +105,12 @@ func GetAppByID(DB *gorm.DB, appID string) (*model.App, error) {
 }
 
 func SaveApp(DB *gorm.DB, app *model.App) (*model.App, error) {
-	if app.ID != "" {
-		if !strings.HasPrefix(app.ID, "app-") {
-			zap.L().Error(MsgAppPrefix)
-			return nil, errutil.ErrInvalidArgument
-		}
-	} else {
+	if app.ID == "" {
 		app.ID = model.GenerateAppID()
+	}
+	if !strings.HasPrefix(app.ID, "app-") {
+		zap.L().Error(MsgAppPrefix)
+		return nil, errutil.ErrInvalidArgument
 	}
 
 	a := datamodel.NewAppFromModel(app)

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -49,6 +49,11 @@ func Init() {
 		panic(err)
 	}
 
+	err = DB.AutoMigrate(&datamodel.Preset{})
+	if err != nil {
+		panic(err)
+	}
+
 	if util.IsDevEnvironment() {
 		seed()
 	}

--- a/datastore/deployment.go
+++ b/datastore/deployment.go
@@ -94,3 +94,21 @@ func SaveDeployment(DB *gorm.DB, deployment *model.Deployment) (*model.Deploymen
 	}
 	return GetDeploymentByID(DB, deployment.ID)
 }
+
+func RemoveDeployment(DB *gorm.DB, id string) error {
+	if !strings.HasPrefix(id, "dpl-") {
+		zap.L().Error(MsgDeploymentPrefix)
+		return errutil.ErrInvalidArgument
+	}
+	var dpl datamodel.Deployment
+	err := DB.Table("deployments").Where(datamodel.Deployment{ID: id}).First(&dpl).Error
+	if err != nil {
+		zap.L().Error(err.Error())
+		return errutil.ErrNotFound
+	}
+	if err := DB.Delete(&dpl).Error; err != nil {
+		zap.L().Error(err.Error())
+		return errutil.ErrUnknown
+	}
+	return nil
+}

--- a/datastore/deployment.go
+++ b/datastore/deployment.go
@@ -71,7 +71,8 @@ func SaveDeployment(DB *gorm.DB, deployment *model.Deployment) (*model.Deploymen
 	if deployment.ID == "" {
 		deployment.ID = model.GenerateDeploymentID()
 	}
-	if deployment.ID != "" && !strings.HasPrefix(deployment.ID, "dpl-") {
+	if !strings.HasPrefix(deployment.ID, "dpl-") {
+		zap.L().Error(MsgDeploymentPrefix)
 		return nil, errutil.ErrInvalidArgument
 	}
 

--- a/datastore/deployment.go
+++ b/datastore/deployment.go
@@ -68,12 +68,11 @@ func SetDeploymentState(DB *gorm.DB, deploymentID string, state model.Deployment
 }
 
 func SaveDeployment(DB *gorm.DB, deployment *model.Deployment) (*model.Deployment, error) {
-	if deployment.ID != "" {
-		if !strings.HasPrefix(deployment.ID, "dpl-") {
-			return nil, errutil.ErrInvalidArgument
-		}
-	} else {
+	if deployment.ID == "" {
 		deployment.ID = model.GenerateDeploymentID()
+	}
+	if deployment.ID != "" && !strings.HasPrefix(deployment.ID, "dpl-") {
+		return nil, errutil.ErrInvalidArgument
 	}
 
 	a := datamodel.NewDeploymentFromModel(deployment)

--- a/datastore/deployment_test.go
+++ b/datastore/deployment_test.go
@@ -1,9 +1,11 @@
 package datastore
 
 import (
+	"bou.ke/monkey"
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
@@ -85,6 +87,43 @@ func TestSetDeploymentState(t *testing.T) {
 	assert.Nil(t, err)
 
 	err = SetDeploymentState(gdb, "dpl-test", model.DeploymentStateReady)
+	assert.Nil(t, err)
+
+	err = db.Close()
+	assert.Nil(t, err)
+
+	err = mock.ExpectationsWereMet()
+	assert.Nil(t, err)
+}
+
+func TestRemoveDeployment(t *testing.T) {
+	monkey.Patch(time.Now, func() time.Time {
+		return time.Unix(0, 0)
+	})
+	defer monkey.UnpatchAll()
+
+	db, mock, err := sqlmock.New()
+	assert.Nil(t, err)
+	ExpectVersionQuery(mock)
+
+	query := "SELECT * FROM `deployments` WHERE `deployments`.`id` = ? ORDER BY `deployments`.`id` LIMIT 1"
+	exec := "DELETE FROM `deployments` WHERE `deployments`.`id` = ?"
+
+	mock.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs("dpl-test").
+		WillReturnRows(GetDeploymentRows())
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(exec)).
+		WithArgs("dpl-test").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectClose()
+
+	gdb, err := OpenGormDB(db)
+	assert.Nil(t, err)
+
+	err = RemoveDeployment(gdb, "dpl-test")
 	assert.Nil(t, err)
 
 	err = db.Close()

--- a/datastore/deployment_test.go
+++ b/datastore/deployment_test.go
@@ -9,12 +9,10 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
-	"github.com/thecodeisalreadydeployed/datamodel"
 	"github.com/thecodeisalreadydeployed/model"
 )
 
 func TestGetDeploymentByAppID(t *testing.T) {
-	fmt.Println(datamodel.DeploymentStructString())
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 	ExpectVersionQuery(mock)
@@ -72,7 +70,7 @@ func TestSetDeploymentState(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
 	ExpectVersionQuery(mock)
-	fmt.Println(datamodel.DeploymentStructString())
+	fmt.Println(DeploymentStructString())
 
 	exec := "UPDATE `deployments` SET `state`=? WHERE `deployments`.`id` = ?"
 

--- a/datastore/error.go
+++ b/datastore/error.go
@@ -1,8 +1,9 @@
 package datastore
 
 var (
-	MsgProjectPrefix    = "Project must have the prj_ prefix."
-	MsgAppPrefix        = "App must have the app_ prefix."
-	MsgDeploymentPrefix = "Deployment must have the dpl_ prefix."
+	MsgProjectPrefix    = "Project must have the prj- prefix."
+	MsgAppPrefix        = "App must have the app- prefix."
+	MsgDeploymentPrefix = "Deployment must have the dpl- prefix."
 	MsgEventPrefix      = "Event must have a proper prefix."
+	MsgPresetPrefix     = "Preset must have the pst- prefix."
 )

--- a/datastore/error.go
+++ b/datastore/error.go
@@ -4,4 +4,5 @@ var (
 	MsgProjectPrefix    = "Project must have the prj_ prefix."
 	MsgAppPrefix        = "App must have the app_ prefix."
 	MsgDeploymentPrefix = "Deployment must have the dpl_ prefix."
+	MsgEventPrefix      = "Event must have a proper prefix."
 )

--- a/datastore/event.go
+++ b/datastore/event.go
@@ -52,7 +52,7 @@ func SaveEvent(DB *gorm.DB, event *model.Event) (*model.Event, error) {
 	if event.ID == "" {
 		event.ID = model.GenerateEventID(event.ExportedAt)
 	}
-	if event.ID != "" && !IsValidKSUID(event.ID) {
+	if !IsValidKSUID(event.ID) {
 		zap.L().Error(MsgEventPrefix)
 		return nil, errutil.ErrInvalidArgument
 	}

--- a/datastore/event_test.go
+++ b/datastore/event_test.go
@@ -1,0 +1,110 @@
+package datastore
+
+import (
+	"bou.ke/monkey"
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/thecodeisalreadydeployed/model"
+	"regexp"
+	"testing"
+	"time"
+)
+
+func TestGetEventsByDeploymentID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.Nil(t, err)
+	ExpectVersionQuery(mock)
+
+	query := "SELECT * FROM `events` WHERE `events`.`deployment_id` = ?"
+	mock.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs("dpl-test").
+		WillReturnRows(GetEventRows())
+	mock.ExpectClose()
+
+	gdb, err := OpenGormDB(db)
+	assert.Nil(t, err)
+
+	actual, err := GetEventsByDeploymentID(gdb, "dpl-test")
+	assert.Nil(t, err)
+
+	expected := &[]model.Event{*GetExpectedEvent()}
+	assert.Equal(t, expected, actual)
+
+	err = db.Close()
+	assert.Nil(t, err)
+
+	err = mock.ExpectationsWereMet()
+	assert.Nil(t, err)
+}
+
+func TestGetEventByID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.Nil(t, err)
+	ExpectVersionQuery(mock)
+
+	query := "SELECT * FROM `events` WHERE id = ? ORDER BY `events`.`id` LIMIT 1"
+	mock.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs("abcdefghijklmnopqrstuvwxyz0").
+		WillReturnRows(GetEventRows())
+	mock.ExpectClose()
+
+	gdb, err := OpenGormDB(db)
+	assert.Nil(t, err)
+
+	actual, err := GetEventByID(gdb, "abcdefghijklmnopqrstuvwxyz0")
+	assert.Nil(t, err)
+
+	expected := GetExpectedEvent()
+	assert.Equal(t, expected, actual)
+
+	err = db.Close()
+	assert.Nil(t, err)
+
+	err = mock.ExpectationsWereMet()
+	assert.Nil(t, err)
+}
+
+func TestSaveEvent(t *testing.T) {
+	monkey.Patch(time.Now, func() time.Time {
+		return time.Unix(0, 0)
+	})
+	defer monkey.UnpatchAll()
+
+	db, mock, err := sqlmock.New()
+	assert.Nil(t, err)
+	ExpectVersionQuery(mock)
+
+	query := "SELECT * FROM `events` WHERE id = ? ORDER BY `events`.`id` LIMIT 1"
+	exec := "UPDATE `events` SET `deployment_id`=?,`text`=?,`type`=?,`exported_at`=?,`created_at`=? WHERE `id` = ?"
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(exec)).
+		WithArgs(
+			"dpl-test",
+			"Downloading dependencies (1/20)",
+			model.INFO,
+			time.Unix(0, 0),
+			time.Unix(0, 0),
+			"abcdefghijklmnopqrstuvwxyz0").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+	mock.ExpectQuery(regexp.QuoteMeta(query)).
+		WithArgs("abcdefghijklmnopqrstuvwxyz0").
+		WillReturnRows(GetEventRows())
+	mock.ExpectClose()
+
+	gdb, err := OpenGormDB(db)
+	assert.Nil(t, err)
+
+	expected := GetExpectedEvent()
+
+	actual, err := SaveEvent(gdb, expected)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+
+	err = db.Close()
+	assert.Nil(t, err)
+
+	err = mock.ExpectationsWereMet()
+	assert.Nil(t, err)
+}

--- a/datastore/preset.go
+++ b/datastore/preset.go
@@ -1,26 +1,113 @@
 package datastore
 
 import (
+	"errors"
+	"github.com/thecodeisalreadydeployed/datamodel"
+	"github.com/thecodeisalreadydeployed/errutil"
 	"github.com/thecodeisalreadydeployed/model"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
+	"strings"
 )
 
 func GetAllPresets(DB *gorm.DB) (*[]model.Preset, error) {
-	return nil, nil
+	var _data []datamodel.Preset
+	err := DB.Table("presets").Scan(&_data).Error
+	if err != nil {
+		zap.L().Error(err.Error())
+		return nil, errutil.ErrNotFound
+	}
+
+	var _ret []model.Preset
+	for _, data := range _data {
+		m := data.ToModel()
+		_ret = append(_ret, m)
+	}
+
+	ret := &_ret
+	return ret, nil
 }
 
 func GetPresetByID(DB *gorm.DB, id string) (*model.Preset, error) {
-	return nil, nil
+	if !strings.HasPrefix(id, "pst-") {
+		zap.L().Error(MsgPresetPrefix)
+		return nil, errutil.ErrInvalidArgument
+	}
+
+	var _data datamodel.Preset
+	err := DB.First(&_data, "id = ?", id).Error
+
+	if err != nil {
+		zap.L().Error(err.Error())
+		return nil, errutil.ErrNotFound
+	}
+
+	ret := _data.ToModel()
+	return &ret, nil
 }
 
-func GetPresetByName(DB *gorm.DB, name string) (*model.Preset, error) {
-	return nil, nil
+func GetPresetsByName(DB *gorm.DB, name string) (*[]model.Preset, error) {
+	var _data []datamodel.Preset
+
+	err := DB.Table("presets").Where(datamodel.Preset{Name: name}).Scan(&_data).Error
+
+	if err != nil {
+		zap.L().Error(err.Error())
+		return nil, errutil.ErrNotFound
+	}
+
+	var _ret []model.Preset
+	for _, data := range _data {
+		m := data.ToModel()
+		_ret = append(_ret, m)
+	}
+
+	ret := &_ret
+	return ret, nil
 }
 
 func SavePreset(DB *gorm.DB, preset *model.Preset) (*model.Preset, error) {
-	return nil, nil
+	if preset.ID != "" {
+		preset.ID = model.GeneratePresetID()
+	}
+	if !IsValidKSUID(preset.ID) {
+		zap.L().Error(MsgPresetPrefix)
+		return nil, errutil.ErrInvalidArgument
+	}
+
+	a := datamodel.NewPresetFromModel(preset)
+	err := DB.Save(a).Error
+
+	if err != nil {
+		zap.L().Error(err.Error())
+
+		if errors.Is(err, gorm.ErrInvalidField) || errors.Is(err, gorm.ErrInvalidData) {
+			return nil, errutil.ErrInvalidArgument
+		}
+
+		if errors.Is(err, gorm.ErrMissingWhereClause) {
+			return nil, errutil.ErrFailedPrecondition
+		}
+
+		return nil, errutil.ErrUnknown
+	}
+	return GetPresetByID(DB, preset.ID)
 }
 
 func RemovePreset(DB *gorm.DB, id string) error {
+	if !IsValidKSUID(id) {
+		zap.L().Error(MsgPresetPrefix)
+		return errutil.ErrInvalidArgument
+	}
+	var a datamodel.Preset
+	err := DB.Table("presets").Where(datamodel.Preset{ID: id}).First(&a).Error
+	if err != nil {
+		zap.L().Error(err.Error())
+		return errutil.ErrNotFound
+	}
+	if err := DB.Delete(&a).Error; err != nil {
+		zap.L().Error(err.Error())
+		return errutil.ErrUnknown
+	}
 	return nil
 }

--- a/datastore/preset.go
+++ b/datastore/preset.go
@@ -28,14 +28,14 @@ func GetAllPresets(DB *gorm.DB) (*[]model.Preset, error) {
 	return ret, nil
 }
 
-func GetPresetByID(DB *gorm.DB, id string) (*model.Preset, error) {
-	if !strings.HasPrefix(id, "pst-") {
+func GetPresetByID(DB *gorm.DB, presetID string) (*model.Preset, error) {
+	if !strings.HasPrefix(presetID, "pst-") {
 		zap.L().Error(MsgPresetPrefix)
 		return nil, errutil.ErrInvalidArgument
 	}
 
 	var _data datamodel.Preset
-	err := DB.First(&_data, "id = ?", id).Error
+	err := DB.First(&_data, "id = ?", presetID).Error
 
 	if err != nil {
 		zap.L().Error(err.Error())

--- a/datastore/preset.go
+++ b/datastore/preset.go
@@ -67,10 +67,10 @@ func GetPresetsByName(DB *gorm.DB, name string) (*[]model.Preset, error) {
 }
 
 func SavePreset(DB *gorm.DB, preset *model.Preset) (*model.Preset, error) {
-	if preset.ID != "" {
+	if preset.ID == "" {
 		preset.ID = model.GeneratePresetID()
 	}
-	if !IsValidKSUID(preset.ID) {
+	if !strings.HasPrefix(preset.ID, "pst-") {
 		zap.L().Error(MsgPresetPrefix)
 		return nil, errutil.ErrInvalidArgument
 	}
@@ -95,7 +95,7 @@ func SavePreset(DB *gorm.DB, preset *model.Preset) (*model.Preset, error) {
 }
 
 func RemovePreset(DB *gorm.DB, id string) error {
-	if !IsValidKSUID(id) {
+	if !strings.HasPrefix(id, "pst-") {
 		zap.L().Error(MsgPresetPrefix)
 		return errutil.ErrInvalidArgument
 	}

--- a/datastore/preset.go
+++ b/datastore/preset.go
@@ -1,0 +1,26 @@
+package datastore
+
+import (
+	"github.com/thecodeisalreadydeployed/model"
+	"gorm.io/gorm"
+)
+
+func GetAllPresets(DB *gorm.DB) (*[]model.Preset, error) {
+	return nil, nil
+}
+
+func GetPresetByID(DB *gorm.DB, id string) (*model.Preset, error) {
+	return nil, nil
+}
+
+func GetPresetByName(DB *gorm.DB, name string) (*model.Preset, error) {
+	return nil, nil
+}
+
+func SavePreset(DB *gorm.DB, preset *model.Preset) (*model.Preset, error) {
+	return nil, nil
+}
+
+func RemovePreset(DB *gorm.DB, id string) error {
+	return nil
+}

--- a/datastore/project.go
+++ b/datastore/project.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"errors"
 	"strings"
 
 	"gorm.io/gorm"
@@ -62,6 +63,15 @@ func SaveProject(DB *gorm.DB, project *model.Project) (*model.Project, error) {
 
 	if err != nil {
 		zap.L().Error(err.Error())
+
+		if errors.Is(err, gorm.ErrInvalidField) || errors.Is(err, gorm.ErrInvalidData) {
+			return nil, errutil.ErrInvalidArgument
+		}
+
+		if errors.Is(err, gorm.ErrMissingWhereClause) {
+			return nil, errutil.ErrFailedPrecondition
+		}
+
 		return nil, errutil.ErrUnknown
 	}
 

--- a/datastore/project.go
+++ b/datastore/project.go
@@ -50,14 +50,14 @@ func GetProjectByID(DB *gorm.DB, id string) (*model.Project, error) {
 }
 
 func SaveProject(DB *gorm.DB, project *model.Project) (*model.Project, error) {
-	if project.ID != "" {
-		if !strings.HasPrefix(project.ID, "prj-") {
-			zap.L().Error(MsgProjectPrefix)
-			return nil, errutil.ErrInvalidArgument
-		}
-	} else {
+	if project.ID == "" {
 		project.ID = model.GenerateProjectID()
 	}
+	if !strings.HasPrefix(project.ID, "prj-") {
+		zap.L().Error(MsgProjectPrefix)
+		return nil, errutil.ErrInvalidArgument
+	}
+
 	p := datamodel.NewProjectFromModel(project)
 	err := DB.Save(p).Error
 

--- a/datastore/testutil.go
+++ b/datastore/testutil.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/thecodeisalreadydeployed/datamodel"
 	"github.com/thecodeisalreadydeployed/model"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
@@ -23,8 +22,53 @@ func OpenGormDB(db *sql.DB) (*gorm.DB, error) {
 	}), &gorm.Config{})
 }
 
+func DeploymentStructString() []string {
+	return []string{
+		"ID",
+		"AppID",
+		"Creator",
+		"Meta",
+		"GitSource",
+		"BuiltAt",
+		"CommittedAt",
+		"DeployedAt",
+		"BuildConfiguration",
+		"CreatedAt",
+		"UpdatedAt",
+		"State",
+	}
+}
+
+func AppStructString() []string {
+	return []string{
+		"ID",
+		"ProjectID",
+		"Name",
+		"GitSource",
+		"CreatedAt",
+		"UpdatedAt",
+		"BuildConfiguration",
+		"Observable",
+	}
+}
+
+func ProjectStructString() []string {
+	return []string{"ID", "Name", "CreatedAt", "UpdatedAt"}
+}
+
+func EventStructString() []string {
+	return []string{
+		"ID",
+		"DeploymentID",
+		"Text",
+		"Type",
+		"ExportedAt",
+		"CreatedAt",
+	}
+}
+
 func GetDeploymentRows() *sqlmock.Rows {
-	return sqlmock.NewRows(datamodel.DeploymentStructString()).
+	return sqlmock.NewRows(DeploymentStructString()).
 		AddRow(
 			"dpl-test",
 			"app-test",
@@ -42,7 +86,7 @@ func GetDeploymentRows() *sqlmock.Rows {
 }
 
 func GetAppRows() *sqlmock.Rows {
-	return sqlmock.NewRows(datamodel.AppStructString()).
+	return sqlmock.NewRows(AppStructString()).
 		AddRow(
 			"app-test",
 			"prj-test",
@@ -56,8 +100,19 @@ func GetAppRows() *sqlmock.Rows {
 }
 
 func GetProjectRows() *sqlmock.Rows {
-	return sqlmock.NewRows(datamodel.ProjectStructString()).
+	return sqlmock.NewRows(ProjectStructString()).
 		AddRow("prj-test", "Best Project", time.Unix(0, 0), time.Unix(0, 0))
+}
+
+func GetEventRows() *sqlmock.Rows {
+	return sqlmock.NewRows(EventStructString()).
+		AddRow(
+			"abcdefghijklmnopqrstuvwxyz0",
+			"dpl-test",
+			"Downloading dependencies (1/20)",
+			model.INFO,
+			time.Unix(0, 0),
+			time.Unix(0, 0))
 }
 
 func GetExpectedDeployment() *model.Deployment {
@@ -96,5 +151,16 @@ func GetExpectedProject() *model.Project {
 		Name:      "Best Project",
 		CreatedAt: time.Unix(0, 0),
 		UpdatedAt: time.Unix(0, 0),
+	}
+}
+
+func GetExpectedEvent() *model.Event {
+	return &model.Event{
+		ID:           "abcdefghijklmnopqrstuvwxyz0",
+		DeploymentID: "dpl-test",
+		Text:         "Downloading dependencies (1/20)",
+		Type:         model.INFO,
+		CreatedAt:    time.Unix(0, 0),
+		ExportedAt:   time.Unix(0, 0),
 	}
 }

--- a/model/parse.go
+++ b/model/parse.go
@@ -63,3 +63,16 @@ func GetBuildConfigurationObject(bc string) BuildConfiguration {
 
 	return buildConfiguration
 }
+
+func GetEncodedString(plain string) string {
+	return base64.StdEncoding.EncodeToString([]byte(plain))
+}
+
+func GetDecodedString(cipher string) string {
+	text, err := base64.StdEncoding.DecodeString(cipher)
+	if err != nil {
+		zap.L().Error(err.Error())
+	}
+
+	return cast.ToString(text)
+}

--- a/model/preset.go
+++ b/model/preset.go
@@ -1,0 +1,16 @@
+package model
+
+import (
+	"fmt"
+	"github.com/thecodeisalreadydeployed/util"
+)
+
+type Preset struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Template string `json:"template"`
+}
+
+func GeneratePresetID() string {
+	return fmt.Sprintf("pst-%s", util.RandomString(25))
+}

--- a/repositoryobserver/repositoryobserver.go
+++ b/repositoryobserver/repositoryobserver.go
@@ -1,7 +1,6 @@
 package repositoryobserver
 
 import (
-	"fmt"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 	"sync"
@@ -43,14 +42,14 @@ func fetchObservableApps(DB *gorm.DB, aChan chan *model.App, wgFetch *sync.WaitG
 
 	if err != nil {
 		zap.L().Error(err.Error())
-		fmt.Println("Unable to fetch observable apps, waiting for the next fetch of observables.")
+		zap.L().Info("Unable to fetch observable apps, waiting for the next fetch of observables.")
 		time.Sleep(WaitAfterErrorInterval)
 		wgFetch.Done()
 		return
 	}
 
 	if len(*apps) == 0 {
-		fmt.Println("All apps are set to not be observed, waiting for the next fetch of observables.")
+		zap.L().Info("All apps are set to not be observed, waiting for the next fetch of observables.")
 		time.Sleep(FetchObservableAppsInterval)
 		wgFetch.Done()
 		return
@@ -87,10 +86,10 @@ func checkGitSource(DB *gorm.DB, app model.App, cChan chan bool, observables *sy
 	}
 	if commit == nil {
 		if duration == -1 {
-			fmt.Println("An error occurred while fetching the repository, waiting for next repository check.")
+			zap.L().Info("An error occurred while fetching the repository, waiting for next repository check.")
 			time.Sleep(WaitAfterErrorInterval)
 		} else {
-			fmt.Println("There are no changes in the application, waiting for next repository check.")
+			zap.L().Info("There are no changes in the application, waiting for next repository check.")
 			time.Sleep(duration)
 		}
 		cChan <- true
@@ -166,6 +165,6 @@ func checkChanges(repoURL string, branch string, currentCommitSHA string) (*stri
 // TODO: Integrate with workload controller
 
 func deployNewRevision() {
-	fmt.Println("Deploying new revision...")
+	zap.L().Info("Deploying new revision...")
 	// direct to workload controller
 }


### PR DESCRIPTION
FEATURES & FIXES:

- datastore + api : create "remove deployment" function
- put foreign key in events table (declaring fields alone doesn't create the relationship)
- saveEntity prefix check fix : changed it so that generated prefixes are also checked right after execution 
- test event functions in datastore
- use logger for repository observer
- refactor datamodel / datastore test
- **completed preset datastore + api**

NEXT INSTALLMENT:

- seed events in dev environment
- preset apiserver integration test
- repository observer further refinement
- **seed default preset template into DB**