### PR TITLE
Dev/jean

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -2,6 +2,7 @@ package apiserver
 
 import (
 	"fmt"
+	"github.com/thecodeisalreadydeployed/repositoryobserver"
 	"log"
 
 	"github.com/thecodeisalreadydeployed/apiserver/auth"
@@ -16,7 +17,7 @@ import (
 	"github.com/thecodeisalreadydeployed/apiserver/validator"
 )
 
-func APIServer(port int, workloadController workloadcontroller.WorkloadController) {
+func APIServer(port int, workloadController workloadcontroller.WorkloadController, observer repositoryobserver.RepositoryObserver) {
 	firebaseAuth := auth.SetupFirebase()
 	gitAPIBackend := gitapi.NewGitAPIBackend(zap.L())
 	validator.Init()

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -28,7 +28,7 @@ func APIServer(port int, workloadController workloadcontroller.WorkloadControlle
 
 	controller.NewProjectController(app.Group("projects", auth.EnsureAuthenticated(firebaseAuth)), workloadController)
 	controller.NewAppController(app.Group("apps", auth.EnsureAuthenticated(firebaseAuth)), workloadController)
-	controller.NewDeploymentController(app.Group("deployments", auth.EnsureAuthenticated(firebaseAuth)), workloadController)
+	controller.NewDeploymentController(app.Group("deployments", auth.EnsureAuthenticated(firebaseAuth)), workloadController, observer)
 	controller.NewPresetController(app.Group("presets", auth.EnsureAuthenticated(firebaseAuth)))
 	controller.NewGitAPIController(app.Group("gitapi", auth.EnsureAuthenticated(firebaseAuth)), gitAPIBackend)
 

--- a/apiserver/controller/deployment.go
+++ b/apiserver/controller/deployment.go
@@ -114,6 +114,12 @@ func deleteDeployment(ctx *fiber.Ctx) error {
 
 func forceRefresh(observer repositoryobserver.RepositoryObserver) fiber.Handler {
 	return func(ctx *fiber.Ctx) error {
+		zap.L().Warn(`Depending on the circumstances, refreshing may not give you the desired results.
+Refreshing to fetch the codebase will only skip the idle duration of the repository observer.
+If the observer is refreshed while it is deploying, the observer will immediately fetch the codebase after deployment.
+If the observer is refreshed while waiting after an error occurs, the observer will not restart the deployment.
+If the observer is refreshed twice while idle, it will deploy the codebase twice.
+Please use the refresh function with full understanding and only when the observer is idle.`)
 		deploymentID := ctx.Params("deploymentID")
 		dpl, err := datastore.GetDeploymentByID(datastore.GetDB(), deploymentID)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-playground/validator/v10 v10.9.0
-	github.com/gofiber/adaptor/v2 v2.1.17
 	github.com/gofiber/fiber/v2 v2.26.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
@@ -24,7 +23,6 @@ require (
 	github.com/kevinburke/ssh_config v1.1.0 // indirect
 	github.com/klauspost/compress v1.14.2 // indirect
 	github.com/matoous/go-nanoid/v2 v2.0.0
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/buildkit v0.9.1
 	github.com/nginxinc/kubernetes-ingress v1.12.0
 	github.com/segmentio/ksuid v1.0.4
@@ -33,6 +31,7 @@ require (
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.7.0
 	github.com/subosito/gotenv v1.2.0
+	github.com/valyala/fasthttp v1.33.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/automaxprocs v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -660,12 +660,8 @@ github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblf
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/gofiber/adaptor/v2 v2.1.17 h1:KokbSH7wiCE3TvsagPu1dH09C1llRTaWvvJxTgQYlpo=
-github.com/gofiber/adaptor/v2 v2.1.17/go.mod h1:RsFHo8J5iDqnt7KOnRrN7b8LhRmzyhlPAuDNunY4yts=
 github.com/gofiber/fiber/v2 v2.26.0 h1:Awnfqp3fqbZzV3wZWMRJ6Xo2U8X0Ls68M7tXjx52NcM=
 github.com/gofiber/fiber/v2 v2.26.0/go.mod h1:7efVWcBOZi1PyMWznnbitjnARPA7nYZxmQXJVod0bo0=
-github.com/gofiber/utils v0.1.2 h1:1SH2YEz4RlNS0tJlMJ0bGwO0JkqPqvq6TbHK9tXZKtk=
-github.com/gofiber/utils v0.1.2/go.mod h1:pacRFtghAE3UoknMOUiXh2Io/nLWSUHtQCi/3QASsOc=
 github.com/gofrs/flock v0.0.0-20190320160742-5135e617513b/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/flock v0.7.3/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/flock v0.8.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=

--- a/main.go
+++ b/main.go
@@ -40,5 +40,5 @@ func main() {
 	repositoryObserver := repositoryobserver.NewRepositoryObserver(zap.L(), datastore.GetDB(), workloadController)
 	go repositoryObserver.ObserveGitSources()
 	go workloadController.ObserveWorkloads()
-	apiserver.APIServer(3000, workloadController)
+	apiserver.APIServer(3000, workloadController, repositoryObserver)
 }

--- a/repositoryobserver/repositoryobserver.go
+++ b/repositoryobserver/repositoryobserver.go
@@ -15,6 +15,7 @@ import (
 
 type RepositoryObserver interface {
 	ObserveGitSources()
+	Refresh(id string)
 }
 
 type repositoryObserver struct {
@@ -23,11 +24,20 @@ type repositoryObserver struct {
 	workloadController workloadcontroller.WorkloadController
 	observables        *sync.Map
 	appChan            chan *model.App
+	refreshChan        map[string]chan bool
 }
 
 func NewRepositoryObserver(logger *zap.Logger, DB *gorm.DB, workloadController workloadcontroller.WorkloadController) RepositoryObserver {
 	appChan := make(chan *model.App)
-	return &repositoryObserver{logger: logger, db: DB, workloadController: workloadController, appChan: appChan, observables: &sync.Map{}}
+	refreshChan := make(map[string]chan bool)
+	return &repositoryObserver{
+		logger:             logger,
+		db:                 DB,
+		workloadController: workloadController,
+		observables:        &sync.Map{},
+		appChan:            appChan,
+		refreshChan:        refreshChan,
+	}
 }
 
 const WaitAfterErrorInterval = 10 * time.Second
@@ -42,6 +52,7 @@ func (observer *repositoryObserver) ObserveGitSources() {
 			for _, app := range *apps {
 				if _, ok := observer.observables.Load(app.ID); !ok {
 					observer.observables.Store(app.ID, nil)
+					observer.refreshChan[app.ID] = make(chan bool)
 					go observer.checkGitSourceWrapper(&app)
 				}
 			}
@@ -53,9 +64,14 @@ func (observer *repositoryObserver) ObserveGitSources() {
 		app := <-observer.appChan
 		if _, ok := observer.observables.Load(app.ID); !ok {
 			observer.observables.Store(app.ID, nil)
+			observer.refreshChan[app.ID] = make(chan bool)
 			go observer.checkGitSourceWrapper(app)
 		}
 	}
+}
+
+func (observer *repositoryObserver) Refresh(id string) {
+	observer.refreshChan[id] <- true
 }
 
 func (observer *repositoryObserver) checkGitSourceWrapper(app *model.App) {
@@ -119,7 +135,12 @@ func (observer *repositoryObserver) checkGitSource(app *model.App) bool {
 		}
 	}
 
-	time.Sleep(duration)
+	select {
+	case <-time.After(duration):
+		break
+	case <-observer.refreshChan[app.ID]:
+		break
+	}
 	return true
 }
 


### PR DESCRIPTION
Depending on the circumstances, refreshing may not give you the desired results.
Refreshing to fetch the codebase will only skip the idle duration of the repository observer.
If the observer is refreshed while it is deploying, the observer will immediately fetch the codebase after deployment.
If the observer is refreshed while waiting after an error occurs, the observer will not restart the deployment.
If the observer is refreshed twice while idle, it will deploy the codebase twice.
Please use the refresh function with full understanding and only when the observer is idle.