### PR TITLE
Dev/jean

### DIFF
--- a/.github/workflows/senior-project.yaml
+++ b/.github/workflows/senior-project.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - ci/senior-project
-      - dev/jean
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/senior-project.yaml
+++ b/.github/workflows/senior-project.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - ci/senior-project
+      - dev/jean
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/datastore/app.go
+++ b/datastore/app.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"errors"
 	"fmt"
+	"github.com/thecodeisalreadydeployed/gitgateway/v2"
 	"go.uber.org/zap"
 	"strings"
 	"sync"
@@ -135,6 +136,15 @@ func SaveApp(DB *gorm.DB, app *model.App) (*model.App, error) {
 	if !strings.HasPrefix(app.ID, "app-") {
 		zap.L().Error(MsgAppPrefix)
 		return nil, errutil.ErrInvalidArgument
+	}
+
+	if app.GitSource.CommitSHA == "" || app.GitSource.CommitMessage == "" || app.GitSource.CommitAuthorName == "" {
+		gs, err := gitgateway.Info(app.GitSource.RepositoryURL, app.GitSource.Branch)
+		if err != nil {
+			zap.L().Error(err.Error())
+			return nil, errutil.ErrInvalidArgument
+		}
+		app.GitSource = gs
 	}
 
 	a := datamodel.NewAppFromModel(app)

--- a/gitgateway/v2/git.go
+++ b/gitgateway/v2/git.go
@@ -33,7 +33,7 @@ type GitGateway interface {
 	GetFiles(branch string) ([]string, error)
 	GetRaw(branch string, path string) (string, error)
 
-	// Calculate average commit interval for the last 10 commit intervals
+	// CommitInterval Calculate average commit interval for the last 10 commit intervals
 	CommitInterval() (time.Duration, error)
 }
 
@@ -277,11 +277,13 @@ const MaximumInterval = 30 * time.Minute
 func (g *gitGateway) CommitInterval() (time.Duration, error) {
 	ref, refErr := g.repo.Head()
 	if refErr != nil {
+		zap.L().Error(refErr.Error())
 		return -1, errutil.ErrFailedPrecondition
 	}
 
 	cIter, logErr := g.repo.Log(&git.LogOptions{From: ref.Hash()})
 	if logErr != nil {
+		zap.L().Error(refErr.Error())
 		return -1, errutil.ErrFailedPrecondition
 	}
 
@@ -380,7 +382,6 @@ func (g *gitGateway) GetFiles(branch string) ([]string, error) {
 }
 
 func (g *gitGateway) GetRaw(branch string, path string) (string, error) {
-	plumbing.NewHash("b3cbd5bbd7e81436d2eee04537ea2b4c0cad4cdf")
 	err := g.Checkout(branch)
 	if err != nil {
 		zap.L().Error(err.Error())

--- a/gitopscontroller/gitopscontroller.go
+++ b/gitopscontroller/gitopscontroller.go
@@ -61,7 +61,7 @@ func NewGitOpsController(logger *zap.Logger) GitOpsController {
 	path := config.DefaultUserspaceRepository()
 	userspace, err := gitgateway.NewGitGatewayLocal(path)
 	if err != nil {
-		panic(err)
+		logger.Error("cannot set userspace")
 	}
 
 	argoCDClient := argocd.NewArgoCDClient(logger.With(zap.String("userspace", path)), "userspace", path)

--- a/repositoryobserver/repositoryobserver.go
+++ b/repositoryobserver/repositoryobserver.go
@@ -109,7 +109,7 @@ func (observer *repositoryObserver) checkGitSource(app *model.App) bool {
 	var duration time.Duration
 	var restart bool
 	for {
-		commit, duration = checkChanges(app.GitSource.RepositoryURL, app.GitSource.Branch, app.GitSource.CommitSHA)
+		commit, duration = checkChanges(app.GitSource.RepositoryURL, app.GitSource.Branch, app.GitSource.CommitSHA, observer)
 
 		if duration > gitgateway.MaximumInterval {
 			duration = gitgateway.MaximumInterval
@@ -172,14 +172,16 @@ func (observer *repositoryObserver) checkObservable(logger *zap.Logger, app *mod
 	}
 }
 
-func checkChanges(repoURL string, branch string, currentCommitSHA string) (*string, time.Duration) {
+func checkChanges(repoURL string, branch string, currentCommitSHA string, observer *repositoryObserver) (*string, time.Duration) {
 	git, err := gitgateway.NewGitGatewayRemote(repoURL)
 	if err != nil {
+		observer.logger.Error("cannot connect to remote", zap.Error(err))
 		return nil, -1
 	}
 
 	duration, err := git.CommitInterval()
 	if err != nil {
+		observer.logger.Error("cannot get commit interval", zap.Error(err))
 		return nil, -1
 	}
 

--- a/repositoryobserver/repositoryobserver.go
+++ b/repositoryobserver/repositoryobserver.go
@@ -16,6 +16,7 @@ import (
 type RepositoryObserver interface {
 	ObserveGitSources()
 	Refresh(id string)
+	CheckChanges(repoURL string, branch string, currentCommitSHA string) (*string, time.Duration)
 }
 
 type repositoryObserver struct {
@@ -109,7 +110,7 @@ func (observer *repositoryObserver) checkGitSource(app *model.App) bool {
 	var duration time.Duration
 	var restart bool
 	for {
-		commit, duration = observer.checkChanges(app.GitSource.RepositoryURL, app.GitSource.Branch, app.GitSource.CommitSHA)
+		commit, duration = observer.CheckChanges(app.GitSource.RepositoryURL, app.GitSource.Branch, app.GitSource.CommitSHA)
 
 		if duration > gitgateway.MaximumInterval {
 			duration = gitgateway.MaximumInterval
@@ -172,7 +173,7 @@ func (observer *repositoryObserver) checkObservable(logger *zap.Logger, app *mod
 	}
 }
 
-func (observer *repositoryObserver) checkChanges(repoURL string, branch string, currentCommitSHA string) (*string, time.Duration) {
+func (observer *repositoryObserver) CheckChanges(repoURL string, branch string, currentCommitSHA string) (*string, time.Duration) {
 	git, err := gitgateway.NewGitGatewayRemote(repoURL)
 	if err != nil {
 		observer.logger.Error("cannot connect to remote", zap.Error(err))

--- a/repositoryobserver/repositoryobserver.go
+++ b/repositoryobserver/repositoryobserver.go
@@ -187,16 +187,19 @@ func (observer *repositoryObserver) checkChanges(repoURL string, branch string, 
 
 	checkoutErr := git.Checkout(branch)
 	if checkoutErr != nil {
+		observer.logger.Error("cannot checkout", zap.Error(err))
 		return nil, -1
 	}
 
 	ref, err := git.Head()
 	if err != nil {
+		observer.logger.Error("cannot get repository head", zap.Error(err))
 		return nil, -1
 	}
 
 	diff, diffErr := git.Diff(currentCommitSHA, ref)
 	if diffErr != nil {
+		observer.logger.Error("cannot get commit diff", zap.Error(err))
 		return nil, -1
 	}
 

--- a/repositoryobserver/repositoryobserver.go
+++ b/repositoryobserver/repositoryobserver.go
@@ -109,7 +109,7 @@ func (observer *repositoryObserver) checkGitSource(app *model.App) bool {
 	var duration time.Duration
 	var restart bool
 	for {
-		commit, duration = checkChanges(app.GitSource.RepositoryURL, app.GitSource.Branch, app.GitSource.CommitSHA, observer)
+		commit, duration = observer.checkChanges(app.GitSource.RepositoryURL, app.GitSource.Branch, app.GitSource.CommitSHA)
 
 		if duration > gitgateway.MaximumInterval {
 			duration = gitgateway.MaximumInterval
@@ -172,7 +172,7 @@ func (observer *repositoryObserver) checkObservable(logger *zap.Logger, app *mod
 	}
 }
 
-func checkChanges(repoURL string, branch string, currentCommitSHA string, observer *repositoryObserver) (*string, time.Duration) {
+func (observer *repositoryObserver) checkChanges(repoURL string, branch string, currentCommitSHA string) (*string, time.Duration) {
 	git, err := gitgateway.NewGitGatewayRemote(repoURL)
 	if err != nil {
 		observer.logger.Error("cannot connect to remote", zap.Error(err))

--- a/repositoryobserver/repositoryobserver_test.go
+++ b/repositoryobserver/repositoryobserver_test.go
@@ -22,7 +22,8 @@ import (
 )
 
 func TestCheckChanges(t *testing.T) {
-	changeString, duration := checkChanges(
+	observer := NewRepositoryObserver(nil, nil, nil)
+	changeString, duration := observer.CheckChanges(
 		"https://github.com/thecodeisalreadydeployed/fixture-monorepo",
 		"main",
 		"37e8e4d20d889924780f2373453a246591b6b11a",
@@ -31,7 +32,7 @@ func TestCheckChanges(t *testing.T) {
 	assert.Equal(t, "5da29979c5ef986dc8ec6aa603e0862310abc96e", *changeString)
 	assert.Equal(t, 19*time.Minute+57*time.Second, duration)
 
-	changeString, duration = checkChanges(
+	changeString, duration = observer.CheckChanges(
 		"https://github.com/thecodeisalreadydeployed/fixture-monorepo",
 		"main",
 		"5da29979c5ef986dc8ec6aa603e0862310abc96e",
@@ -40,7 +41,7 @@ func TestCheckChanges(t *testing.T) {
 	assert.Nil(t, changeString)
 	assert.Equal(t, 19*time.Minute+57*time.Second, duration)
 
-	changeString, duration = checkChanges(
+	changeString, duration = observer.CheckChanges(
 		"https://github.com/thecodeisalreadydeployed/fixture-nest",
 		"main",
 		"62139be31792ab4a43c00eadcc8af6cadd90ee66",
@@ -49,7 +50,7 @@ func TestCheckChanges(t *testing.T) {
 	assert.Equal(t, "14bc77fc515e6d66b8d9c15126ee49ca55faf879", *changeString)
 	assert.Equal(t, 723*time.Hour+39*time.Minute+44*time.Second+500*time.Millisecond, duration)
 
-	changeString, duration = checkChanges(
+	changeString, duration = observer.CheckChanges(
 		"https://github.com/thecodeisalreadydeployed/fixture-nest",
 		"dev",
 		"62139be31792ab4a43c00eadcc8af6cadd90ee66",


### PR DESCRIPTION
The old code, when creating app, does not populate commit SHA, so repository observer writes error when trying to compare commits for checking changes.

I added logic to populate commit SHA when create app if it is empty.